### PR TITLE
Prevent closing polls by others

### DIFF
--- a/lib/Command/Poll.php
+++ b/lib/Command/Poll.php
@@ -70,6 +70,11 @@ To close a running poll send a message with:
 		}
 
 		if (($payload === 'close' || $payload === 'end') && $poll instanceof \OCA\TalkSimplePoll\Model\Poll) {
+			if (!empty($poll->getUserId()) && $poll->getUserId() !== $input->getArgument('userId')) {
+				$output->writeln('The poll can only be closed by the author.');
+				return;
+			}
+
 			$poll->setStatus(\OCA\TalkSimplePoll\Model\Poll::STATUS_CLOSED);
 			$this->pollMapper->update($poll);
 


### PR DESCRIPTION
Now only the author can close the currently running poll (except if the poll was made by a guest, which can still be closed by anyone).

Of course it would be better if it was configurable by poll, but it is just a quick hack for the conference server :-)