### PR TITLE
Only show current number of votes when someone votes

### DIFF
--- a/lib/Command/Base.php
+++ b/lib/Command/Base.php
@@ -41,6 +41,16 @@ class Base extends \OC\Core\Command\Base {
 		$this->voteMapper = $voteMapper;
 	}
 
+	public function showPollVotes(OutputInterface $output, \OCA\TalkSimplePoll\Model\Poll $poll): void {
+		$output->write($poll->getQuestion());
+		$options = json_decode($poll->getOptions(), true);
+
+		$votes = $this->voteMapper->findByPoll($poll);
+		$totalVotes = count($votes);
+
+		$output->writeln(' (' . $totalVotes . ' votes)');
+	}
+
 	public function showPoll(OutputInterface $output, \OCA\TalkSimplePoll\Model\Poll $poll): void {
 		$output->write($poll->getQuestion());
 		$options = json_decode($poll->getOptions(), true);

--- a/lib/Command/Vote.php
+++ b/lib/Command/Vote.php
@@ -95,6 +95,6 @@ To vote for option 2, send a message with:
 			$this->voteMapper->insert($vote);
 		}
 
-		$this->showPoll($output, $poll);
+		$this->showPollVotes($output, $poll);
 	}
 }


### PR DESCRIPTION
Showing the full current results when someone votes makes the poll "spammy", so now only the total number of votes are shown instead.

Of course it would be better if it was configurable by poll, but it is just a quick hack for the conference server :-)